### PR TITLE
feat(wr): conditional header set

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function wreq(bundler) {
 
     if (prevError) return next(prevError)
 
-    res.setHeader('content-type', 'text/javascript')
+    if (res) res.setHeader('content-type', 'text/javascript')
 
     return next(null, buffer)
 


### PR DESCRIPTION
Only set a header if the `res` object exists; useful when piping directly into streams :sparkles: